### PR TITLE
Make the argument "--in-place" not overridable

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,8 +1,7 @@
 - id: cmake-format
   name: cmake-format
   description: cmake-format can format your listfiles nicely so that they don't look like crap.
-  entry: cmake-format
-  args: [--in-place]
+  entry: cmake-format --in-place
   language: python
   types: [cmake]
 


### PR DESCRIPTION
Because I was astonished when realized that cmake-format doesn't work anymore after adding arguments
Something like that
```
        args:
          - --line-width=119
          - --tab-size=4
```